### PR TITLE
Update Camera Permission

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,7 @@ export default function App() {
   const [flashMode, setFlashMode] = React.useState('off')
 
   const __startCamera = async () => {
-    const {status} = await Camera.requestPermissionsAsync()
+    const {status} = await Camera.requestCameraPermissionsAsync()
     console.log(status)
     if (status === 'granted') {
       setStartCamera(true)


### PR DESCRIPTION
Previous method is now deprecated and this is the new method. I used the previous one and got the error, Hence Recommending this change.